### PR TITLE
Fixed JEI potion fluids registered without Bottle tag

### DIFF
--- a/src/main/java/com/simibubi/create/compat/jei/CreateJEI.java
+++ b/src/main/java/com/simibubi/create/compat/jei/CreateJEI.java
@@ -370,10 +370,15 @@ public class CreateJEI implements IModPlugin {
 	@Override
 	public void registerExtraIngredients(IExtraIngredientRegistration registration) {
 		Collection<Potion> potions = ForgeRegistries.POTIONS.getValues();
-		Collection<FluidStack> potionFluids = new ArrayList<>(potions.size());
+		Collection<FluidStack> potionFluids = new ArrayList<>(potions.size() * 3);
 		for (Potion potion : potions) {
-			FluidStack potionFluid = PotionFluid.of(1000, potion);
-			potionFluids.add(potionFluid);
+			// @goshante: Ingame potion fluids always have Bottle tag that specifies
+			// to what bottle type this potion belongs
+			// Potion fluid without this tag wouldn't be recognized by other mods
+			for (PotionFluid.BottleType bottleType : PotionFluid.BottleType.values()) {
+				FluidStack potionFluid = PotionFluid.of(1000, potion, bottleType);
+				potionFluids.add(potionFluid);
+			}
 		}
 		registration.addExtraIngredients(ForgeTypes.FLUID_STACK, potionFluids);
 	}

--- a/src/main/java/com/simibubi/create/content/fluids/potion/PotionFluid.java
+++ b/src/main/java/com/simibubi/create/content/fluids/potion/PotionFluid.java
@@ -36,15 +36,17 @@ public class PotionFluid extends VirtualFluid {
 		super(properties, source);
 	}
 
-	public static FluidStack of(int amount, Potion potion) {
-		FluidStack fluidStack = new FluidStack(AllFluids.POTION.get()
-			.getSource(), amount);
+	public static FluidStack of(int amount, Potion potion, BottleType bottleType) {
+
+		FluidStack fluidStack;
+		fluidStack = new FluidStack(AllFluids.POTION.get().getSource(), amount);
 		addPotionToFluidStack(fluidStack, potion);
+		NBTHelper.writeEnum(fluidStack.getOrCreateTag(), "Bottle", bottleType);
 		return fluidStack;
 	}
 
 	public static FluidStack withEffects(int amount, Potion potion, List<MobEffectInstance> customEffects) {
-		FluidStack fluidStack = of(amount, potion);
+		FluidStack fluidStack = of(amount, potion, BottleType.REGULAR);
 		appendEffects(fluidStack, customEffects);
 		return fluidStack;
 	}

--- a/src/main/java/com/simibubi/create/content/fluids/potion/PotionFluidHandler.java
+++ b/src/main/java/com/simibubi/create/content/fluids/potion/PotionFluidHandler.java
@@ -42,7 +42,7 @@ public class PotionFluidHandler {
 		return stack.getItem() instanceof PotionItem && !(stack.getCraftingRemainingItem()
 			.getItem() instanceof BucketItem);
 	}
-	
+
 	public static Pair<FluidStack, ItemStack> emptyPotion(ItemStack stack, boolean simulate) {
 		FluidStack fluid = getFluidFromPotionItem(stack);
 		if (!simulate)
@@ -69,8 +69,7 @@ public class PotionFluidHandler {
 	public static FluidStack getFluidFromPotion(Potion potion, BottleType bottleType, int amount) {
 		if (potion == Potions.WATER && bottleType == BottleType.REGULAR)
 			return new FluidStack(Fluids.WATER, amount);
-		FluidStack fluid = PotionFluid.of(amount, potion);
-		NBTHelper.writeEnum(fluid.getOrCreateTag(), "Bottle", bottleType);
+		FluidStack fluid = PotionFluid.of(amount, potion, bottleType);
 		return fluid;
 	}
 


### PR DESCRIPTION
Actually Create potion fluid has 3 variations: Regular, Splash and Lingering
You was adding untagged potion fluids and they wasn't working in other mods

I fixed that and now it really works